### PR TITLE
프로젝트 셋업 관련 내용 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist/
 
 .DS_Store
 credentials.json
+
+venv/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+colorama==0.4.4
+commonmark==0.9.1
+psutil==5.8.0
+Pygments==2.9.0
+rich==10.5.0
+schedule==1.1.0


### PR DESCRIPTION
# 수정 사항
- python 가상환경 (virtual env)의 라우트인 venv (npm의 node_modules 와 같은것) 을 .gitignore에 추가했습니다
- 의존성 관련 정보를 담는 requirements.txt 가 없어 이를 추가했습니다 :)